### PR TITLE
Make exceptions Python 3 compatible

### DIFF
--- a/examples/hack21.py
+++ b/examples/hack21.py
@@ -23,7 +23,7 @@ mech.set_handle_robots(False)
 # Get the starting search page
 try:
     mech.open("http://search.cpan.org")
-except HTTPError, e:
+except HTTPError as e:
     sys.exit("%d: %s" % (e.code, e.msg))
 
 # Select the form, fill the fields, and submit
@@ -32,13 +32,13 @@ mech["query"] = "Lester"
 mech["mode"] = ["author"]
 try:
     mech.submit()
-except HTTPError, e:
+except HTTPError as e:
     sys.exit("post failed: %d: %s" % (e.code, e.msg))
 
 # Find the link for "Andy"
 try:
     mech.follow_link(text_regex=re.compile("Andy"))
-except HTTPError, e:
+except HTTPError as e:
     sys.exit("post failed: %d: %s" % (e.code, e.msg))
 
 # Get all the tarballs

--- a/mechanize/_form_controls.py
+++ b/mechanize/_form_controls.py
@@ -1945,7 +1945,7 @@ class HTMLForm:
         control = self.find_control(name)
         try:
             control.value = value
-        except AttributeError, e:
+        except AttributeError as e:
             raise ValueError(str(e))
 
     def get_value(

--- a/mechanize/_http.py
+++ b/mechanize/_http.py
@@ -92,9 +92,9 @@ class MechanizeRobotFileParser(robotparser.RobotFileParser):
                       timeout=self._timeout)
         try:
             f = self._opener.open(req)
-        except HTTPError, f:
+        except HTTPError as f:
             pass
-        except (IOError, socket.error, OSError), exc:
+        except (IOError, socket.error, OSError) as exc:
             debug_robots("ignoring error opening %r: %s" %
                          (self.url, exc))
             return

--- a/mechanize/_mechanize.py
+++ b/mechanize/_mechanize.py
@@ -282,13 +282,13 @@ class Browser(UserAgentBase):
         success = True
         try:
             response = UserAgentBase.open(self, request, data)
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             success = False
             if error.fp is None:  # not a response
                 raise
             response = error
 
-#         except (IOError, socket.error, OSError), error:
+#         except (IOError, socket.error, OSError) as error:
 #             Yes, urllib2 really does raise all these :-((
 #             See test_urllib2.py for examples of socket.gaierror and OSError,
 #             plus note that FTPHandler raises IOError.

--- a/mechanize/_opener.py
+++ b/mechanize/_opener.py
@@ -321,7 +321,7 @@ def wrapped_open(urlopen, process_response_object, fullurl, data=None,
     success = True
     try:
         response = urlopen(fullurl, data, timeout)
-    except urllib2.HTTPError, error:
+    except urllib2.HTTPError as error:
         success = False
         if error.fp is None:  # not a response
             raise

--- a/mechanize/_urllib2_fork.py
+++ b/mechanize/_urllib2_fork.py
@@ -1368,7 +1368,7 @@ class FileHandler(BaseHandler):
             ):
                 return addinfourl(open(localfile, 'rb'),
                                   headers, 'file:' + file)
-        except OSError, msg:
+        except OSError as msg:
             # urllib2 users shouldn't expect OSErrors coming from urlopen()
             raise URLError(msg)
         raise URLError('file not on local host')
@@ -1400,7 +1400,7 @@ class FTPHandler(BaseHandler):
 
         try:
             host = socket.gethostbyname(host)
-        except socket.error, msg:
+        except socket.error as msg:
             raise URLError(msg)
         path, attrs = splitattr(req.get_selector())
         dirs = path.split('/')

--- a/test-tools/testprogram.py
+++ b/test-tools/testprogram.py
@@ -143,7 +143,7 @@ def kill_posix(pid, report_hook):
             report_hook("forcefully killing")
             try:
                 os.kill(pid, signal.SIGKILL)
-            except OSError, exc:
+            except OSError as exc:
                 if exc.errno != errno.ECHILD:
                     raise
     finally:

--- a/test/test_browser.doctest
+++ b/test/test_browser.doctest
@@ -151,7 +151,7 @@ non-visiting.
 >>> def raises(exc_class, fn, *args, **kwds):
 ...     try:
 ...         fn(*args, **kwds)
-...     except exc_class, exc:
+...     except exc_class as exc:
 ...         return True
 ...     return False
 >>> def test_state(br):

--- a/test/test_cookies.py
+++ b/test/test_cookies.py
@@ -61,7 +61,7 @@ class TempfileTestMixin:
         for fn in self._tempfiles:
             try:
                 os.remove(fn)
-            except IOError, exc:
+            except IOError as exc:
                 if exc.errno != errno.ENOENT:
                     raise
 
@@ -1262,7 +1262,7 @@ class CookieJarPersistenceTests(TempfileTestMixin, unittest.TestCase):
         finally:
             try:
                 os.remove(filename)
-            except IOError, exc:
+            except IOError as exc:
                 if exc.errno != errno.ENOENT:
                     raise
 
@@ -1279,7 +1279,7 @@ class CookieJarPersistenceTests(TempfileTestMixin, unittest.TestCase):
         finally:
             try:
                 os.remove(filename)
-            except IOError, exc:
+            except IOError as exc:
                 if exc.errno != errno.ENOENT:
                     raise
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -375,7 +375,7 @@ class ResponseTests(TestCase):
         opener.set_seekable_responses(True)
         try:
             opener.open(urljoin(self.uri, "nonexistent"))
-        except mechanize.HTTPError, exc:
+        except mechanize.HTTPError as exc:
             self.assert_("HTTPError instance" in repr(exc))
 
     def test_no_seek(self):
@@ -385,7 +385,7 @@ class ResponseTests(TestCase):
             self.assert_(not hasattr(r, "seek"))
             try:
                 opener.open(urljoin(self.uri, "nonexistent"))
-            except mechanize.HTTPError, exc:
+            except mechanize.HTTPError as exc:
                 self.assert_(not hasattr(exc, "seek"))
 
         # mechanize.UserAgent
@@ -410,7 +410,7 @@ class ResponseTests(TestCase):
             self.assertEqual(data, r.read(), r.get_data())
             try:
                 opener.open(urljoin(self.uri, "nonexistent"))
-            except mechanize.HTTPError, exc:
+            except mechanize.HTTPError as exc:
                 data = exc.read()
                 if excs_also:
                     exc.seek(0)
@@ -678,7 +678,7 @@ class CookieJarTests(TestCase):
             cj = mechanize.MozillaCookieJar(filename=filename)
             try:
                 cj.revert()
-            except IOError, exc:
+            except IOError as exc:
                 if exc.errno != errno.ENOENT:
                     raise
             return cj

--- a/test/test_opener.doctest
+++ b/test/test_opener.doctest
@@ -34,7 +34,7 @@ the result is raised rather than returned.
 ...     _opener.wrapped_open(urlopen, response_hook,
 ...                          "http://example.com", "data"
 ...                          )
-... except Exception, exc:
+... except Exception as exc:
 ...     print exc
 fullurl 'http://example.com'
 data 'data'
@@ -51,7 +51,7 @@ Other exceptions get ignored, since they're not response objects.
 ...     _opener.wrapped_open(urlopen, response_hook,
 ...                          "http://example.com", "data"
 ...                          )
-... except Exception, exc:
+... except Exception as exc:
 ...     print exc
 fullurl 'http://example.com'
 data 'data'

--- a/test/test_opener.py
+++ b/test/test_opener.py
@@ -266,7 +266,7 @@ class OpenerTests(unittest.TestCase):
         try:
             try:
                 op.retrieve(url, reporthook=verif.callback)
-            except mechanize.ContentTooShortError, exc:
+            except mechanize.ContentTooShortError as exc:
                 filename, headers = exc.result
                 self.assertNotEqual(filename, tfn)
                 self.assertEqual(headers["foo"], 'Bar')

--- a/test/test_urllib2.py
+++ b/test/test_urllib2.py
@@ -1141,7 +1141,7 @@ class HandlerTests(mechanize._testcase.TestCase):
         # case 1. it's not an HTTPError
         try:
             h.http_error_default(request, response, code, msg, response.info())
-        except mechanize.HTTPError, exc:
+        except mechanize.HTTPError as exc:
             self.assert_(exc is not response)
             self.assert_(exc.fp is response)
         else:
@@ -1151,7 +1151,7 @@ class HandlerTests(mechanize._testcase.TestCase):
         error = mechanize.HTTPError(url, code, msg, "fake headers", response)
         try:
             h.http_error_default(request, error, code, msg, error.info())
-        except mechanize.HTTPError, exc:
+        except mechanize.HTTPError as exc:
             self.assert_(exc is error)
         else:
             self.assert_(False)
@@ -1199,7 +1199,7 @@ class HandlerTests(mechanize._testcase.TestCase):
         req = Request(url)
         try:
             h.http_request(req)
-        except mechanize.HTTPError, e:
+        except mechanize.HTTPError as e:
             self.assert_(e.request == req)
             self.assert_(e.code == 403)
         # new host: reload robots.txt (even though the host and port are

--- a/test/test_urllib2_localnet.py
+++ b/test/test_urllib2_localnet.py
@@ -429,7 +429,7 @@ class TestUrlopen(TestCase):
 
         try:
             mechanize.urlopen('http://localhost:%s/weeble' % handler.port)
-        except mechanize.URLError, f:
+        except mechanize.URLError as f:
             pass
         else:
             self.fail('404 should raise URLError')


### PR DESCRIPTION
Make the exceptions Python 3 compatible as this is an easy first step to
full Python 3 support.