### PR TITLE
Fix some typos and cosmetic issues in the docs

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -74,7 +74,7 @@ For example, the `User-Agent` header may need to be set
 browser.
 
 Check that the browser is able to do manually what you're trying to achieve
-programatically.  Make sure that what you do manually is *exactly* the same as
+programmatically.  Make sure that what you do manually is *exactly* the same as
 what you're trying to do from Python -- you may simply be hitting a server bug
 that only gets revealed if you view pages in a particular order, for example.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -63,7 +63,7 @@ Cookies
 Which HTTP cookie protocols does mechanize support?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Netscape and [RFC 2965](http://www.ietf.org/rfc/rfc2965.txt).  RFC 2965
+Netscape and `RFC 2965 <http://www.ietf.org/rfc/rfc2965.txt>`_.  RFC 2965
 handling is switched off by default.
 
 What about RFC 2109?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -134,7 +134,7 @@ Why doesn't `<some control>` turn up in the data returned by `.click*()` when th
 
 Either the control is disabled, or it is not successful for some other
 reason. 'Successful' (see `HTML 4
-specification <http://www.w3.org/TR/REC-html40/interact/forms.html#h-17.13.2>`_.
+specification <http://www.w3.org/TR/REC-html40/interact/forms.html#h-17.13.2>`_)
 means that the control will cause data to get sent to the server.
 
 Why does mechanize not follow the HTML 4.0 / RFC 1866 standards for `RADIO` and multiple-selection `SELECT` controls?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -219,7 +219,7 @@ code. The simplest case is if the JavaScript is setting some cookies.
 In that case you can inspect the cookies in your browser and emulate
 setting them in mechanize with :meth:`mechanize.Browser.set_simple_cookie()`.
 
-More complex is to use your browser developer tool sto see exactly what
+More complex is to use your browser developer tools to see exactly what
 requests are sent by the browser and emulate them in mechanize
 by using :class:`mechanize.Request` to create the request manually
 and open it with :meth:`mechanize.Browser.open()`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,7 +97,7 @@ You may control the browser's policy by using the methods of
     br.set_request_gzip(True)
     # Log information about HTTP redirects and Refreshes.
     br.set_debug_redirects(True)
-    # Log HTTP response bodies (ie. the HTML, most of the time).
+    # Log HTTP response bodies (i.e. the HTML, most of the time).
     br.set_debug_responses(True)
     # Print HTTP headers.
     br.set_debug_http(True)

--- a/mechanize/_form_controls.py
+++ b/mechanize/_form_controls.py
@@ -1003,7 +1003,7 @@ class ListControl(Control):
     def set_item_disabled(self, disabled, name, by_label=False, nr=None):
         """Set disabled state of named list item in a ListControl.
 
-        disabled: boolean disabled state
+        :arg disabled: boolean disabled state
 
         """
         deprecation("control.get(...).disabled = <boolean>")
@@ -1012,7 +1012,7 @@ class ListControl(Control):
     def set_all_items_disabled(self, disabled):
         """Set disabled state of all list items in a ListControl.
 
-        disabled: boolean disabled state
+        :arg disabled: boolean disabled state
 
         """
         for o in self.items:
@@ -1963,7 +1963,9 @@ class HTMLForm:
 
         If only name and value arguments are supplied, equivalent to
 
-        form[name]
+        .. code-block:: python
+
+            form[name]
 
         """
         if by_label:
@@ -1994,7 +1996,9 @@ class HTMLForm:
 
         If only name and value arguments are supplied, equivalent to
 
-        form[name] = value
+        .. code-block:: python
+
+            form[name] = value
 
         """
         if by_label:
@@ -2100,7 +2104,7 @@ class HTMLForm:
             label=None):
         """Select / deselect named list item.
 
-        selected: boolean selected state
+        :arg selected: boolean selected state
 
         """
         self._find_list_control(name, type, kind, id, label, nr).set(
@@ -2141,8 +2145,10 @@ class HTMLForm:
         For example, if a checkbox has a single item named "on", the following
         two calls are equivalent:
 
-        control.toggle("on")
-        control.toggle_single()
+        .. code-block:: python
+
+            control.toggle("on")
+            control.toggle_single()
 
         """  # by_label ignored and deprecated
         self._find_list_control(name, type, kind, id, label,
@@ -2192,12 +2198,11 @@ class HTMLForm:
         Note the following useful HTML attributes of file upload controls (see
         HTML 4.01 spec, section 17):
 
-        accept: comma-separated list of content types that the server will
-         handle correctly; you can use this to filter out non-conforming files
-        size: XXX IIRC, this is indicative of whether form wants multiple or
-         single files
-
-        maxlength: XXX hint of max content length in bytes?
+          * `accept`: comma-separated list of content types that the server will
+             handle correctly; you can use this to filter out non-conforming files
+          * `size`: XXX IIRC, this is indicative of whether form wants multiple or
+             single files
+          * `maxlength`: XXX hint of max content length in bytes?
 
         """
         self.find_control(

--- a/mechanize/_mechanize.py
+++ b/mechanize/_mechanize.py
@@ -758,14 +758,14 @@ class Browser(UserAgentBase):
             as this argument, if supplied
         :param name: as for text and text_regex, but matched
             against the name HTML attribute of the link tag
-        :url: as for text and text_regex, but matched against the
+        :param url: as for text and text_regex, but matched against the
             URL of the link tag (note this matches against Link.url, which is a
             relative or absolute URL according to how it was written in the
             HTML)
         :param tag: element name of opening tag, e.g. "a"
         :param predicate: a function taking a Link object as its single
             argument, returning a boolean result, indicating whether the links
-        :nr: matches the nth link that matches all other criteria (default 0)
+        :param nr: matches the nth link that matches all other criteria (default 0)
 
         """
         try:

--- a/mechanize/_useragent.py
+++ b/mechanize/_useragent.py
@@ -325,8 +325,8 @@ class UserAgentBase(_opener.OpenerDirector):
 
         Other logger names relevant to this module:
 
-        `"mechanize.http_responses"`
-        `"mechanize.cookies"`
+        * `mechanize.http_responses`
+        * `mechanize.cookies`
 
         To turn on everything:
 


### PR DESCRIPTION
Fix some typos, a broken link and some cosmetic/formatting issues in the docs.