### PR TITLE
Enable universal wheel build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [flake8]
 max-line-length = 120
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
This allows wheel files distributed by mechanize to be compatible on both python 2 and 3.