### PR TITLE
Adjust for custom charset encoding of form request variables with Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /docs/_*
 *.egg-info/
 *.py[co]
+.venv*

--- a/mechanize/_form_controls.py
+++ b/mechanize/_form_controls.py
@@ -59,6 +59,13 @@ def compress_whitespace(text):
 
 
 def isstringlike(x):
+
+    try:
+        if isinstance(x, (str, bytes)):
+            return True
+    except:
+        pass
+
     try:
         x + ""
     except Exception:

--- a/test/test_form.py
+++ b/test/test_form.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: iso-8859-1 -*-
+# -*- coding: utf-8 -*-
 
 # Copyright 2002-2005 John J. Lee <jjl@pobox.com>
 # Copyright 2005 Gary Poster
@@ -207,6 +207,29 @@ class LWPFormTests(unittest.TestCase):
         self.assertTrue(request_method(req) == "GET")
         self.assertTrue(
             req.get_full_url() == "http://localhost/abc?firstname=Gisle+Aas")
+
+
+class EncodingTests(unittest.TestCase):
+
+    def _forms(self):
+        file = BytesIO("""<form method="POST"><input name="name" value=""></form>""")
+        return parse_file(file, "http://localhost/", backwards_compat=False)
+
+    def testFillForm(self):
+        forms = self._forms()
+        form = forms[0]
+        form["name"] = u"Räuber Hotzenplotz".encode('iso-8859-1')
+        req = form.click()
+
+        def request_method(req):
+            if req.has_data():
+                return "POST"
+            else:
+                return "GET"
+
+        print(req.get_full_url())
+        self.assertEqual(request_method(req), "POST")
+        self.assertEqual(req.get_data(), 'name=R%E4uber+Hotzenplotz')
 
 
 def get_header(req, name):


### PR DESCRIPTION
Hi there,

thank you all for conceiving and maintaining `mechanize`. While using it that long already, we are finally happy to contribute something.

When upgrading to Python 3, we encountered the same issue as #32 when the form should be submitted in "iso-8859-1" encoding.

When sending latin-encoded form fields, "mechanize" bailed out with

    TypeError: must assign a string

on Python 3 while everything worked fine on Python 2 here. This PR accounts for that by also accepting readily encoded `bytes` when setting form fields, which then worked flawlessly for us. An appropriate test nails the amended behavior.

Thanks a bunch already for looking at this.

With kind regards,
Andreas.