### PR TITLE
set_html method

### DIFF
--- a/mechanize/_headersutil.py
+++ b/mechanize/_headersutil.py
@@ -20,6 +20,8 @@ from .polyglot import is_string
 
 
 def is_html_file_extension(url, allow_xhtml):
+    if url is None:
+        return False
     ext = os.path.splitext(_rfc3986.urlsplit(url)[2])[1]
     html_exts = [".htm", ".html"]
     if allow_xhtml:
@@ -27,7 +29,7 @@ def is_html_file_extension(url, allow_xhtml):
     return ext in html_exts
 
 
-def is_html(ct_headers, url, allow_xhtml=False):
+def is_html(ct_headers, url=None, allow_xhtml=False):
     """
     ct_headers: Sequence of Content-Type headers
     url: Response URL

--- a/mechanize/_mechanize.py
+++ b/mechanize/_mechanize.py
@@ -120,6 +120,8 @@ class Browser(UserAgentBase):
         received html/xhtml content. See the builtin
         :func:`mechanize._html.content_parser()` function for details
         on the interface this function must support.
+    :param factory_class: HTML Factory class to use. Defaults to
+                            :class:`mechanize.Factory`
 
     """
 
@@ -133,6 +135,7 @@ class Browser(UserAgentBase):
             history=None,
             request_class=None,
             content_parser=None,
+            factory_class=Factory,
             allow_xhtml=False, ):
         """
         Only named arguments should be passed to this constructor.
@@ -147,7 +150,7 @@ class Browser(UserAgentBase):
         if request_class is None:
             request_class = _request.Request
 
-        factory = Factory(allow_xhtml=allow_xhtml)
+        factory = factory_class(allow_xhtml=allow_xhtml)
         factory.set_request_class(request_class)
         if content_parser is not None:
             factory.set_content_parser(content_parser)

--- a/mechanize/_mechanize.py
+++ b/mechanize/_mechanize.py
@@ -20,6 +20,7 @@ from ._headersutil import normalize_header_name
 from ._html import Factory
 from ._useragent import UserAgentBase
 from .polyglot import pathname2url, HTTPError, is_string, iteritems
+from ._response import make_response
 
 
 class BrowserStateError(Exception):
@@ -382,6 +383,16 @@ class Browser(UserAgentBase):
         # we want self.request to be assigned even if UserAgentBase.open
         # fails
         self.request = request
+
+    def set_html(self, html, url=None):
+        """Set the response to dummy with given HTML, and URL if given.
+
+        Allows you to then parse that HTML, especially to extract forms
+        information. If there is no URL then any URL-related methods
+        will fail.
+        """
+        response = make_response(html, [("Content-type", "text/html")], url)
+        self._set_response(response, True)
 
     def geturl(self):
         """Get URL of current document."""

--- a/mechanize/_mechanize.py
+++ b/mechanize/_mechanize.py
@@ -384,12 +384,11 @@ class Browser(UserAgentBase):
         # fails
         self.request = request
 
-    def set_html(self, html, url=None):
+    def set_html(self, html, url="http://example.com/"):
         """Set the response to dummy with given HTML, and URL if given.
 
         Allows you to then parse that HTML, especially to extract forms
-        information. If there is no URL then any URL-related methods
-        will fail.
+        information. If no URL was given then the default is "example.com".
         """
         response = make_response(html, [("Content-type", "text/html")], url)
         self._set_response(response, True)

--- a/mechanize/_response.py
+++ b/mechanize/_response.py
@@ -426,7 +426,7 @@ class closeable_response:
 
 def test_response(data='test data',
                   headers=[],
-                  url="http://example.com/",
+                  url=None,
                   code=200,
                   msg="OK"):
     return make_response(data, headers, url, code, msg)
@@ -434,7 +434,7 @@ def test_response(data='test data',
 
 def test_html_response(data='test data',
                        headers=[],
-                       url="http://example.com/",
+                       url=None,
                        code=200,
                        msg="OK"):
     headers += [("Content-type", "text/html")]

--- a/mechanize/_response.py
+++ b/mechanize/_response.py
@@ -441,7 +441,7 @@ def test_html_response(data='test data',
     return make_response(data, headers, url, code, msg)
 
 
-def make_response(data, headers, url, code, msg):
+def make_response(data, headers, url=None, code=200, msg="OK"):
     """Convenient factory for objects implementing response interface.
 
     data: string containing response body data

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1081,7 +1081,7 @@ class HttplibTests(mechanize._testcase.TestCase):
 <form>
     <input type="text" name="p" value="q"></input>
 </form>
-</body></html>"""))
+</body></html>""", url="http://example.com/"))
 
         def has_a(form):
             try:

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -11,7 +11,6 @@ import mechanize
 import mechanize._response
 import mechanize._testcase
 from mechanize._gzip import HTTPGzipProcessor, compress_readable_output
-from mechanize._response import test_html_response
 from mechanize.polyglot import (HTTPConnection, addinfourl, codepoint_to_chr,
                                 create_response_info, iteritems, unicode_type)
 
@@ -447,13 +446,9 @@ class BrowserTests(TestCase):
 
     def test_forms(self):
         import mechanize
-        url = "http://example.com"
 
         b = TestBrowser()
-        r = test_html_response(
-            url=url,
-            headers=[("content-type", "text/html")],
-            data="""\
+        b.set_html("""\
 <html>
 <head><title>Title</title></head>
 <body>
@@ -470,8 +465,6 @@ class BrowserTests(TestCase):
 </body>
 </html>
 """)
-        b.add_handler(make_mock_handler()([("http_open", r)]))
-        r = b.open(url)
 
         forms = list(b.forms())
         self.assertEqual(len(forms), 2)
@@ -1058,7 +1051,6 @@ class HttplibTests(mechanize._testcase.TestCase):
             407, 'Proxy-Authenticate: Basic realm="realm"\r\n\r\n')
         test_state(test_one_visit([ph, hh, ah]))
 
-        from mechanize._response import test_response
         br = TestBrowser2()
         html = b"""\
         <html><body>
@@ -1066,22 +1058,20 @@ class HttplibTests(mechanize._testcase.TestCase):
         <form><input type="text" name="b" /></form>
         </body></html>
         """
-        response = test_response(html, headers=[("Content-type", "text/html")])
         self.assertRaises(mechanize.BrowserStateError, br.global_form)
-        br.set_response(response)
+        br.set_html(html)
         self.assertEqual(str(br.global_form().find_control(nr=0).name), 'a')
         self.assertEqual(len(list(br.forms())), 1)
         self.assertEqual(str(next(iter(br.forms())).find_control(nr=0).name), 'b')
 
-        from mechanize._response import test_html_response
         br = TestBrowser2()
-        br.visit_response(test_html_response(b"""\
+        br.set_html("""\
 <html><head><title></title></head><body>
 <input type="text" name="a" value="b"></input>
 <form>
     <input type="text" name="p" value="q"></input>
 </form>
-</body></html>""", url="http://example.com/"))
+</body></html>""")
 
         def has_a(form):
             try:

--- a/test/test_forms.doctest
+++ b/test/test_forms.doctest
@@ -13,7 +13,7 @@ as well as mechanize._rfc3986).  Fixed in ClientForm r33622 .
 ...         '<input type="submit" name="s"/></form>' % method
 ...         )
 ...         br = mechanize.Browser()
-...         response = test_response(data, [("content-type", "text/html")])
+...         response = test_response(data, [("content-type", "text/html")], "http://example.com/")
 ...         br.set_response(response)
 ...         br.select_form(nr=0)
 ...         forms.append(br.form)

--- a/test/test_forms.doctest
+++ b/test/test_forms.doctest
@@ -13,8 +13,7 @@ as well as mechanize._rfc3986).  Fixed in ClientForm r33622 .
 ...         '<input type="submit" name="s"/></form>' % method
 ...         )
 ...         br = mechanize.Browser()
-...         response = test_response(data, [("content-type", "text/html")], "http://example.com/")
-...         br.set_response(response)
+...         br.set_html(data, "http://example.com/")
 ...         br.select_form(nr=0)
 ...         forms.append(br.form)
 ...     return forms
@@ -34,13 +33,12 @@ error.
 
 >>> import mechanize
 >>> br = mechanize.Browser()
->>> r = mechanize._response.test_html_response("""\
+>>> br.set_html("""\
 ... <form>
 ... <input type="text" name="foo" value="a"></input><!!!>
 ... <input type="text" name="bar" value="b"></input>
 ... </form>
 ... """)
->>> br.set_response(r)
 >>> try:
 ...     br.select_form(nr=0)
 ... except mechanize.ParseError:

--- a/test/test_html.py
+++ b/test/test_html.py
@@ -13,18 +13,16 @@ class RegressionTests(TestCase):
     def test_close_base_tag(self):
         # any document containing a </base> tag used to cause an exception
         br = mechanize.Browser()
-        response = test_html_response("</base>")
-        br.set_response(response)
+        br.set_html("</base>")
         list(br.links())
 
     def test_bad_base_tag(self):
         # a document with a base tag with no href used to cause an exception
         br = mechanize.Browser()
-        response = test_html_response(
+        br.set_html(
             "<BASE TARGET='_main'><a href='http://example.com/'>eg</a>",
             url="http://example.com/",
         )
-        br.set_response(response)
         list(br.links())
 
 

--- a/test/test_html.py
+++ b/test/test_html.py
@@ -21,7 +21,9 @@ class RegressionTests(TestCase):
         # a document with a base tag with no href used to cause an exception
         br = mechanize.Browser()
         response = test_html_response(
-            "<BASE TARGET='_main'><a href='http://example.com/'>eg</a>")
+            "<BASE TARGET='_main'><a href='http://example.com/'>eg</a>",
+            url="http://example.com/",
+        )
         br.set_response(response)
         list(br.links())
 
@@ -71,7 +73,7 @@ class MiscTests(TestCase):
 
         def get_first_link_text(html):
             factory = Factory()
-            response = test_html_response(html)
+            response = test_html_response(html, url="http://example.com/")
             factory.set_response(response)
             return list(factory.links())[0].text
 

--- a/test/test_urllib2.py
+++ b/test/test_urllib2.py
@@ -1365,7 +1365,7 @@ class HandlerTests(mechanize._testcase.TestCase):
             rp._sleep = st.sleep
             rp.http_response(
                 Request("http://example.com"),
-                test_response(headers=[("Refresh", header)]), )
+                test_response(headers=[("Refresh", header)], url="http://example.com/"), )
             self.assertEqual(expect_refresh, opener.called)
             st.verify()
 


### PR DESCRIPTION
This PR implements a `set_html` method on Browser, with tests and docstring. The motivation for this was I wanted to use the excellent form-parsing functionality within mechanize, but after a day I couldn't find how to make a fake response (though I have now done so, I argue it is still not ideal). The relevant tests have been adjusted to use `set_html`, and I believe they are now more idiomatic for it. I claim this shows how useful this functionality is.

It also parameterises the factory class used by Browser, since that was how I first implemented the above, and seems like a good idea.

Finally, it sets defaults for some of the not-very-documented `make_response` function's args.