### PR TITLE
stop mutating test_html_response default parameter

### DIFF
--- a/mechanize/_response.py
+++ b/mechanize/_response.py
@@ -432,13 +432,13 @@ def test_response(data='test data',
     return make_response(data, headers, url, code, msg)
 
 
+_html_header = [("Content-type", "text/html")]
 def test_html_response(data='test data',
                        headers=[],
                        url=None,
                        code=200,
                        msg="OK"):
-    headers += [("Content-type", "text/html")]
-    return make_response(data, headers, url, code, msg)
+    return make_response(data, headers + _html_header, url, code, msg)
 
 
 def make_response(data, headers, url=None, code=200, msg="OK"):

--- a/test/test_html.py
+++ b/test/test_html.py
@@ -67,6 +67,11 @@ class TitleTests(TestCase):
 
 class MiscTests(TestCase):
 
+    def test_util_func(self):
+        headers1 = str(test_html_response('').info())
+        headers2 = str(test_html_response('').info())
+        self.assertEqual(headers1, headers2)
+
     def test_link_parsing(self):
 
         def get_first_link_text(html):


### PR DESCRIPTION
Stumbled over this while experimenting with using `test_html_response` (as I didn't realise you'd released 0.4.5).

If you call it >100 times, it will start causing failures because the default headers list, which is currently being mutated, grows to over 100 long, which causes:

```
http.client.HTTPException: got more than 100 headers
```
