### PR TITLE
Change decoding in http to iso-8859-1 instead of unicode

### DIFF
--- a/mechanize/_http.py
+++ b/mechanize/_http.py
@@ -25,7 +25,7 @@ from ._request import Request
 from ._response import response_seek_wrapper
 from ._urllib2_fork import BaseHandler, HTTPError
 from ._equiv import HTTPEquivParser
-from .polyglot import create_response_info, RobotFileParser, is_py2, as_unicode
+from .polyglot import create_response_info, RobotFileParser, is_py2
 
 debug = logging.getLogger("mechanize").debug
 debug_robots = logging.getLogger("mechanize.robots").debug
@@ -88,6 +88,11 @@ class MechanizeRobotFileParser(RobotFileParser):
     def set_timeout(self, timeout):
         self._timeout = timeout
 
+    def as_iso_88591(self, x, encoding='iso-8859-1'):
+        if isinstance(x, bytes):
+            x = x.decode(encoding)
+        return x
+
     def read(self):
         """Reads the robots.txt URL and feeds it to the parser."""
         if self._opener is None:
@@ -119,7 +124,7 @@ class MechanizeRobotFileParser(RobotFileParser):
             if is_py2:
                 self.parse(lines)
             else:
-                self.parse(map(as_unicode, lines))
+                self.parse(map(self.as_iso_88591, lines))
 
 
 class RobotExclusionError(HTTPError):


### PR DESCRIPTION
I did not find a good way of passing an argument, it was nested a bit down. If you give me some pointers maybe I can add that instead.

Anyway, since parsing of for example Nordic languages fail with a UnicodeDecodeError on `polyglot.as_unicode` when opening a

```
browser = mechanize.Browser()
browser.open("https://register.sportadmin.se/")
```

an example line to as_unicode that fail looks like
`b'<div style="font-size: 28px;color: #3b3933;margin-bottom: 20px;">F\xf6rening</div>'`

This is the traceback
```
Traceback (most recent call last):

  File " tests.py", line 36, in <module>
    S = sportadmin.Sportadmin()

  File "n.py", line 119, in __init__
    self.cookie = self._load_cookie()

  File "n.py", line 124, in _load_cookie
    browser.open(SPORTADMIN_URL)

  File "mechanize\mechanize\_mechanize.py", line 257, in open
    return self._mech_open(url_or_request, data, timeout=timeout)

  File "mechanize\mechanize\_mechanize.py", line 287, in _mech_open
    response = UserAgentBase.open(self, request, data)

  File "mechanize\mechanize\_opener.py", line 188, in open
    req = meth(req)

  File "mechanize\mechanize\_http.py", line 181, in http_request
    self.rfp.read()

  File "mechanize\mechanize\_http.py", line 130, in read
    self.parse(map(as_unicode, lines))

  File "C:\temp\Apps\Anaconda64\lib\urllib\robotparser.py", line 95, in parse
    for line in lines:

  File "mechanize\mechanize\polyglot.py", line 200, in as_unicode
    x = x.decode('utf-8')

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf6 in position 66: invalid start byte
```