### PR TITLE
Fix CookieTests following fix for CPython #130631

### DIFF
--- a/test/test_cookies.py
+++ b/test/test_cookies.py
@@ -332,9 +332,13 @@ class CookieTests(unittest.TestCase):
         cookie = c._cookies["www.acme.com"]['/foo/']['"spam"']
         assert cookie.name == '"spam"'
         assert cookie.value is None
-        assert lwp_cookie_str(cookie) == (
+        assert lwp_cookie_str(cookie) in (
+            r'"spam"; path="/foo/"; domain=www.acme.com; '
+            'path_spec; discard; version=0',
+            # prior to fix for https://github.com/python/cpython/issues/130631:
             r'"spam"; path="/foo/"; domain="www.acme.com"; '
-            'path_spec; discard; version=0')
+            'path_spec; discard; version=0',
+            )
         old_str = repr(c)
         c.save(ignore_expires=True, ignore_discard=True)
         try:


### PR DESCRIPTION
The fix for https://github.com/python/cpython/issues/130631 in Python 3.14.0b1 (also cherry-picked to 3.13, but not yet released) causes `www.acme.com` to be unquoted in cookie strings.  Adjust a test to cope with this.